### PR TITLE
[Bug]: エラーが起きた際にアプリがクラッシュしてしまう

### DIFF
--- a/app/src/main/java/com/example/flush/data/repository/ThrowingItemRepositoryImpl.kt
+++ b/app/src/main/java/com/example/flush/data/repository/ThrowingItemRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -29,7 +30,8 @@ class ThrowingItemRepositoryImpl @Inject constructor(
             Ok(throwingItems)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to get throwing items", e)
-            Err(e.message ?: "Unknown error")
+            val errorMessage = getErrorMessage(e)
+            Err(errorMessage)
         }
 
     override suspend fun createThrowingItem(throwingItem: ThrowingItem): Result<Unit, String> =
@@ -38,7 +40,8 @@ class ThrowingItemRepositoryImpl @Inject constructor(
             Ok(Unit)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to create throwing item", e)
-            Err(e.message ?: "Unknown error")
+            val errorMessage = getErrorMessage(e)
+            Err(errorMessage)
         }
 
     override suspend fun uploadImage(throwingItemId: String, imageUrl: Uri): Result<String, String> =
@@ -49,7 +52,8 @@ class ThrowingItemRepositoryImpl @Inject constructor(
             Ok(result.toString())
         } catch (e: Exception) {
             Log.e(TAG, "Failed to upload image", e)
-            Err(e.message ?: "Unknown error")
+            val errorMessage = getErrorMessage(e)
+            Err(errorMessage)
         }
 
     override suspend fun uploadTextureBitmap(throwingItemId: String, textureBitmap: Bitmap): Result<String, String> =
@@ -61,10 +65,18 @@ class ThrowingItemRepositoryImpl @Inject constructor(
             Ok(result.toString())
         } catch (e: Exception) {
             Log.e(TAG, "Failed to upload texture bitmap", e)
-            Err(e.message ?: "Unknown error")
+            val errorMessage = getErrorMessage(e)
+            Err(errorMessage)
         }
 
     companion object {
         private const val TAG = "ThrowingItemRepositoryImpl"
+
+        private fun getErrorMessage(e: Exception): String {
+            return when (e) {
+                is FirebaseFirestoreException -> "データベースエラーが発生しました"
+                else -> "予期せぬエラーが発生しました"
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/flush/domain/use_case/SignInWithGoogleUseCase.kt
+++ b/app/src/main/java/com/example/flush/domain/use_case/SignInWithGoogleUseCase.kt
@@ -7,9 +7,9 @@ import com.example.flush.domain.model.User
 import com.example.flush.domain.repository.AuthRepository
 import com.example.flush.domain.repository.UserRepository
 import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
+import com.github.michaelbull.result.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -32,7 +32,7 @@ class SignInWithGoogleUseCase @Inject constructor(
                         )
                         userRepository.saveUser(user)
                     }
-                Ok(Unit)
+                    .map { Unit }
             } catch (e: Exception) {
                 Log.e(TAG, "Error signing in with Google", e)
                 Err(e.message ?: "Unknown error")

--- a/app/src/main/java/com/example/flush/domain/use_case/SignUpWithEmailUseCase.kt
+++ b/app/src/main/java/com/example/flush/domain/use_case/SignUpWithEmailUseCase.kt
@@ -6,9 +6,9 @@ import com.example.flush.domain.model.User
 import com.example.flush.domain.repository.AuthRepository
 import com.example.flush.domain.repository.UserRepository
 import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
+import com.github.michaelbull.result.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -32,7 +32,7 @@ class SignUpWithEmailUseCase @Inject constructor(
                         )
                         userRepository.createUser(user)
                     }
-                Ok(Unit)
+                    .map { Unit }
             } catch (e: Exception) {
                 Log.e(TAG, "Sign up failed", e)
                 Err(e.message ?: "Unknown error")

--- a/app/src/main/java/com/example/flush/ui/feature/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/search/SearchViewModel.kt
@@ -1,10 +1,11 @@
 package com.example.flush.ui.feature.search
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.example.flush.domain.use_case.GetCurrentUserUseCase
 import com.example.flush.domain.use_case.GetThrowingItemUseCase
 import com.example.flush.ui.base.BaseViewModel
-import com.github.michaelbull.result.mapBoth
+import com.github.michaelbull.result.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -36,11 +37,15 @@ class SearchViewModel @Inject constructor(
 
     private fun fetchThrowingItems() {
         viewModelScope.launch {
-            val result = getThrowingItemUseCase()
-            result.mapBoth(
-                { updateUiState { it.copy(throwingItems = result.value) } },
-                { sendEffect(SearchUiEffect.ShowToast(result.error)) },
-            )
+            try {
+                val result = getThrowingItemUseCase()
+                result.fold(
+                    { updateUiState { it.copy(throwingItems = result.value) } },
+                    { sendEffect(SearchUiEffect.ShowToast(result.error)) },
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to fetch throwing items", e)
+            }
         }
     }
 
@@ -51,5 +56,9 @@ class SearchViewModel @Inject constructor(
                     updateUiState { it.copy(currentUser = user) }
                 }
         }
+    }
+
+    companion object {
+        private const val TAG = "SearchViewModel"
     }
 }

--- a/app/src/main/java/com/example/flush/ui/feature/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/flush/ui/feature/sign_up/SignUpViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.flush.ui.feature.sign_up
 
 import android.content.Intent
+import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.lifecycle.viewModelScope
@@ -8,7 +9,7 @@ import com.example.flush.domain.use_case.RequestGoogleOneTapAuthUseCase
 import com.example.flush.domain.use_case.SignInWithGoogleUseCase
 import com.example.flush.domain.use_case.SignUpWithEmailUseCase
 import com.example.flush.ui.base.BaseViewModel
-import com.github.michaelbull.result.mapBoth
+import com.github.michaelbull.result.fold
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -30,41 +31,58 @@ class SignUpViewModel @Inject constructor(
 
     fun submitRegister() {
         viewModelScope.launch {
-            updateUiState { it.copy(isLoading = true) }
-            val email = uiState.value.email
-            val password = uiState.value.password
-            val result = signUpWithEmailUseCase(email, password)
-            updateUiState { it.copy(isLoading = false) }
-            result.mapBoth(
-                { sendEffect(SignUpUiEffect.NavigateToSearch) },
-                { sendEffect(SignUpUiEffect.ShowToast(it)) },
-            )
+            try {
+                updateUiState { it.copy(isLoading = true) }
+                val email = uiState.value.email
+                val password = uiState.value.password
+                val result = signUpWithEmailUseCase(email, password)
+                updateUiState { it.copy(isLoading = false) }
+                result.fold(
+                    { sendEffect(SignUpUiEffect.NavigateToSearch) },
+                    { sendEffect(SignUpUiEffect.ShowToast(it)) },
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Sign up failed", e)
+            }
         }
     }
 
     fun startGoogleSignIn(launcher: ActivityResultLauncher<IntentSenderRequest>) {
         viewModelScope.launch {
-            updateUiState { it.copy(isLoading = true) }
-            val result = requestGoogleOneTapAuthUseCase()
-            result.mapBoth(
-                { launcher.launch(it) },
-                { sendEffect(SignUpUiEffect.ShowToast(it)) },
-            )
+            try {
+                updateUiState { it.copy(isLoading = true) }
+                val result = requestGoogleOneTapAuthUseCase()
+                result.fold(
+                    { launcher.launch(it) },
+                    { sendEffect(SignUpUiEffect.ShowToast(it)) },
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to sign in with Google", e)
+            }
         }
     }
 
     fun handleSignInResult(launcherResult: Intent?) {
         viewModelScope.launch {
             if (launcherResult != null) {
-                val result = signInWithGoogleUseCase(launcherResult)
-                updateUiState { it.copy(isLoading = false) }
-                result.mapBoth(
-                    { sendEffect(SignUpUiEffect.NavigateToSearch) },
-                    { sendEffect(SignUpUiEffect.ShowToast(it)) },
-                )
+                try {
+                    val result = signInWithGoogleUseCase(launcherResult)
+                    updateUiState { it.copy(isLoading = false) }
+                    result.fold(
+                        { sendEffect(SignUpUiEffect.NavigateToSearch) },
+                        { sendEffect(SignUpUiEffect.ShowToast(it)) },
+                    )
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to sign in with Google", e)
+                    sendEffect(SignUpUiEffect.ShowToast("Failed to sign in with Google"))
+                }
             } else {
-                sendEffect(SignUpUiEffect.ShowToast("Failed to sign in"))
+                sendEffect(SignUpUiEffect.ShowToast("サインアップに失敗しました"))
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "SignUpViewModel"
     }
 }


### PR DESCRIPTION
## 概要
Pull Request #7 で実装したkotlin-resultでうまくエラーハンドリング出来ていなかったため、エラーが発生したらアプリがクラッシュしてしまっていた。そのため、エラーが起きてもアプリがクラッシュしないように変更した。また、ユーザに表示する文字列を変更した。これにより、どのようなエラーが起きたのかユーザがわかるようになった。（メールアドレスの形式が間違っていたのかなど）

## 実施Issue
#9 

## 原因と対処
リポジトリ側でErrを送ってはいたが、使用する側（ViewModel）でtry-catchしていなく、アプリがクラッシュしてしまっていた。そのため、ViewModel側にtry-catchの処理を加えた。
