### PR TITLE
[Bug]: detektがプロジェクト全体にかかるようになっていない

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,10 +90,6 @@ dependencies {
 //    Splash Screen
     implementation(libs.androidx.core.splashscreen)
 
-//    detekt
-    detektPlugins(libs.detekt.compose)
-    detektPlugins(libs.detekt.formatting)
-
 //    Hilt
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.android)
@@ -108,20 +104,4 @@ dependencies {
 //    Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
-}
-
-allprojects {
-    apply(plugin = "io.gitlab.arturbosch.detekt")
-
-    detekt {
-        config.setFrom("$rootDir/config/detekt/detekt.yml")
-        buildUponDefaultConfig = true
-
-        source.setFrom(files("src/main/java"))
-        autoCorrect = true
-    }
-
-    tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
-        jvmTarget = "17"
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.gitlab.arturbosch.detekt.Detekt
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -6,7 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
 
 //    detekt
-    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.detekt)
 
 //    KSP
     alias(libs.plugins.ksp) apply false
@@ -22,4 +24,28 @@ plugins {
 
 //    Secrets Gradle Plugin
     alias(libs.plugins.secrets.gradle.plugin) apply false
+}
+
+val detektFormatting = libs.detekt.formatting
+val detektCompose = libs.detekt.compose
+
+subprojects {
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+
+    dependencies {
+        detektPlugins(detektFormatting)
+        detektPlugins(detektCompose)
+    }
+
+    detekt {
+        config.setFrom("$rootDir/config/detekt/detekt.yml")
+        buildUponDefaultConfig = true
+
+        source.setFrom(files("src/main/java"))
+        autoCorrect = true
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        jvmTarget = "17"
+    }
 }

--- a/core/di/src/main/java/com/example/flush/core/di/RepositoryModule.kt
+++ b/core/di/src/main/java/com/example/flush/core/di/RepositoryModule.kt
@@ -1,14 +1,14 @@
 package com.example.flush.core.di
 
+import com.example.flush.core.repository.AuthRepository
+import com.example.flush.core.repository.EmotionAnalysisRepository
+import com.example.flush.core.repository.ThrowingItemRepository
+import com.example.flush.core.repository.UserRepository
 import com.example.flush.data.api.EmotionAnalysisApi
 import com.example.flush.data.repository.AuthRepositoryImpl
 import com.example.flush.data.repository.EmotionAnalysisRepositoryImpl
 import com.example.flush.data.repository.ThrowingItemRepositoryImpl
 import com.example.flush.data.repository.UserRepositoryImpl
-import com.example.flush.core.repository.AuthRepository
-import com.example.flush.core.repository.EmotionAnalysisRepository
-import com.example.flush.core.repository.ThrowingItemRepository
-import com.example.flush.core.repository.UserRepository
 import com.google.android.gms.auth.api.identity.SignInClient
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore

--- a/core/domain/src/main/java/com/example/flush/core/domain/SignInWithGoogleUseCase.kt
+++ b/core/domain/src/main/java/com/example/flush/core/domain/SignInWithGoogleUseCase.kt
@@ -7,12 +7,12 @@ import com.example.flush.core.model.User
 import com.example.flush.core.repository.AuthRepository
 import com.example.flush.core.repository.UserRepository
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import com.github.michaelbull.result.Result
 
 class SignInWithGoogleUseCase @Inject constructor(
     private val authRepository: AuthRepository,

--- a/core/domain/src/main/java/com/example/flush/core/domain/SignUpWithEmailUseCase.kt
+++ b/core/domain/src/main/java/com/example/flush/core/domain/SignUpWithEmailUseCase.kt
@@ -6,12 +6,12 @@ import com.example.flush.core.model.User
 import com.example.flush.core.repository.AuthRepository
 import com.example.flush.core.repository.UserRepository
 import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import com.github.michaelbull.result.Result
 
 class SignUpWithEmailUseCase @Inject constructor(
     private val authRepository: AuthRepository,
@@ -28,7 +28,7 @@ class SignUpWithEmailUseCase @Inject constructor(
                             email = firebaseUser.email ?: "",
                             name = "名無し",
                             iconUrl = "https://firebasestorage.googleapis.com/v0/b/flush-de17e.firebasestorage.app/o/" +
-                                    "default_icon.png?alt=media&token=c77ba166-ca8a-4504-b70e-c4749c8f9cfc",
+                                "default_icon.png?alt=media&token=c77ba166-ca8a-4504-b70e-c4749c8f9cfc",
                         )
                         userRepository.createUser(user)
                     }

--- a/core/model/src/main/java/com/example/flush/core/model/EmotionAnalysisModel.kt
+++ b/core/model/src/main/java/com/example/flush/core/model/EmotionAnalysisModel.kt
@@ -1,6 +1,5 @@
 package com.example.flush.core.model
 
-
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/core/repository/src/main/java/com/example/flush/core/repository/AuthRepository.kt
+++ b/core/repository/src/main/java/com/example/flush/core/repository/AuthRepository.kt
@@ -2,9 +2,9 @@ package com.example.flush.core.repository
 
 import android.content.Intent
 import androidx.activity.result.IntentSenderRequest
+import com.github.michaelbull.result.Result
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseUser
-import com.github.michaelbull.result.Result
 
 interface AuthRepository {
     fun getCurrentUser(): FirebaseUser?

--- a/core/repository/src/main/java/com/example/flush/core/repository/EmotionAnalysisRepository.kt
+++ b/core/repository/src/main/java/com/example/flush/core/repository/EmotionAnalysisRepository.kt
@@ -2,7 +2,6 @@ package com.example.flush.core.repository
 
 import com.example.flush.core.model.Emotion
 
-
 interface EmotionAnalysisRepository {
     suspend fun analyzeEmotion(text: String): Emotion
 

--- a/core/repository/src/main/java/com/example/flush/core/repository/UserRepository.kt
+++ b/core/repository/src/main/java/com/example/flush/core/repository/UserRepository.kt
@@ -1,9 +1,8 @@
 package com.example.flush.core.repository
 
-
 import com.example.flush.core.model.User
-import kotlinx.coroutines.flow.Flow
 import com.github.michaelbull.result.Result
+import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     suspend fun createUser(user: User): Result<Unit, String>

--- a/core/utils/src/main/java/com/example/flush/core/utils/ktx/Bitmap.kt
+++ b/core/utils/src/main/java/com/example/flush/core/utils/ktx/Bitmap.kt
@@ -1,4 +1,4 @@
-package com.example.flush.ktx
+package com.example.flush.core.utils.ktx
 
 import android.graphics.Bitmap
 import java.io.ByteArrayOutputStream

--- a/core/utils/src/main/java/com/example/flush/core/utils/ktx/Long.kt
+++ b/core/utils/src/main/java/com/example/flush/core/utils/ktx/Long.kt
@@ -1,4 +1,4 @@
-package com.example.flush.ktx
+package com.example.flush.core.utils.ktx
 
 import java.time.Instant
 import java.time.ZoneId

--- a/data/repository/src/main/java/com/example/flush/data/repository/AuthRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/flush/data/repository/AuthRepositoryImpl.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import android.util.Log
 import androidx.activity.result.IntentSenderRequest
 import com.example.flush.core.repository.AuthRepository
-import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.SignInClient
 import com.google.firebase.auth.AuthResult

--- a/data/repository/src/main/java/com/example/flush/data/repository/EmotionAnalysisRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/flush/data/repository/EmotionAnalysisRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.example.flush.data.repository
 
-import com.example.flush.data.api.EmotionAnalysisApi
 import com.example.flush.core.model.AnalyzeEmotionRequest
 import com.example.flush.core.model.Emotion
 import com.example.flush.core.model.GeminiRequest
 import com.example.flush.core.repository.EmotionAnalysisRepository
+import com.example.flush.data.api.EmotionAnalysisApi
 import javax.inject.Inject
 
 class EmotionAnalysisRepositoryImpl @Inject constructor(

--- a/data/repository/src/main/java/com/example/flush/data/repository/ThrowingItemRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/flush/data/repository/ThrowingItemRepositoryImpl.kt
@@ -3,12 +3,12 @@ package com.example.flush.data.repository
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
-import com.example.flush.ktx.toByteArray
-import com.github.michaelbull.result.Result
 import com.example.flush.core.model.ThrowingItem
 import com.example.flush.core.repository.ThrowingItemRepository
+import com.example.flush.core.utils.ktx.toByteArray
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.storage.FirebaseStorage

--- a/data/repository/src/main/java/com/example/flush/data/repository/UserRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/example/flush/data/repository/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.example.flush.core.model.User
 import com.example.flush.core.repository.UserRepository
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
 import com.google.firebase.storage.FirebaseStorage
@@ -14,7 +15,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
-import com.github.michaelbull.result.Result
 
 class UserRepositoryImpl @Inject constructor(
     private val firestore: FirebaseFirestore,

--- a/feature/auth_selection/src/main/java/com/example/flush/feature/auth_selection/AuthSelectionScreenContent.kt
+++ b/feature/auth_selection/src/main/java/com/example/flush/feature/auth_selection/AuthSelectionScreenContent.kt
@@ -12,15 +12,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.NavigateToSignInButtonHeight
-import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.NavigateToSignUpButtonHeight
-import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.PoittoImageSize
 import com.example.flush.core.designsystem.component.DisplayMediumText
 import com.example.flush.core.designsystem.component.FilledButton
 import com.example.flush.core.designsystem.component.Image
 import com.example.flush.core.designsystem.component.OutlinedButton
 import com.example.flush.core.designsystem.theme.dimensions.Paddings
 import com.example.flush.core.designsystem.theme.dimensions.Weights
+import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.NavigateToSignInButtonHeight
+import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.NavigateToSignUpButtonHeight
+import com.example.flush.feature.auth_selection.AuthSelectionScreenDimensions.PoittoImageSize
 
 @Composable
 fun AuthSelectionScreenContent(

--- a/feature/auth_selection/src/main/java/com/example/flush/feature/auth_selection/AuthSelectionViewModel.kt
+++ b/feature/auth_selection/src/main/java/com/example/flush/feature/auth_selection/AuthSelectionViewModel.kt
@@ -4,5 +4,5 @@ import com.example.flush.core.base.BaseViewModel
 
 class AuthSelectionViewModel :
     BaseViewModel<AuthSelectionUiState, AuthSelectionUiEvent, AuthSelectionUiEffect>(
-        AuthSelectionUiState()
+        AuthSelectionUiState(),
     )

--- a/feature/post/src/main/java/com/example/flush/feature/post/PostScreenDimensions.kt
+++ b/feature/post/src/main/java/com/example/flush/feature/post/PostScreenDimensions.kt
@@ -1,5 +1,5 @@
 package com.example.flush.feature.post
 
-data object AnimationConfig {
+data object PostScreenDimensions {
     const val AnimationDuration = 5000
 }

--- a/feature/post/src/main/java/com/example/flush/feature/post/PostScreenThrowingPhaseContent.kt
+++ b/feature/post/src/main/java/com/example/flush/feature/post/PostScreenThrowingPhaseContent.kt
@@ -31,11 +31,11 @@ import com.example.flush.core.designsystem.theme.dimensions.Paddings
 import com.example.flush.core.ui.LocalEngine
 import com.example.flush.core.ui.LocalGraphicsView
 import com.example.flush.core.ui.LocaleEnvironment
-import com.example.flush.feature.post.AnimationConfig.AnimationDuration
 import com.example.flush.core.utils.SceneviewUtils.applyTextureToAlpha
 import com.example.flush.core.utils.SceneviewUtils.calculateScaleFromBitmapSize
 import com.example.flush.core.utils.SceneviewUtils.createModelNode
 import com.example.flush.core.utils.SceneviewUtils.loadTextureBitmap
+import com.example.flush.feature.post.PostScreenDimensions.AnimationDuration
 import io.github.sceneview.Scene
 import io.github.sceneview.math.Position
 import io.github.sceneview.math.Rotation

--- a/feature/post/src/main/java/com/example/flush/feature/post/PostViewModel.kt
+++ b/feature/post/src/main/java/com/example/flush/feature/post/PostViewModel.kt
@@ -62,7 +62,7 @@ class PostViewModel @Inject constructor(
     fun startAnimation() {
         viewModelScope.launch {
             updateUiState { it.copy(animationState = PostUiAnimationState.Running) }
-            delay(AnimationConfig.AnimationDuration.toLong())
+            delay(PostScreenDimensions.AnimationDuration.toLong())
             updateUiState { it.copy(animationState = PostUiAnimationState.Completed) }
         }
     }

--- a/feature/search/src/main/java/com/example/flush/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/example/flush/feature/search/SearchScreen.kt
@@ -30,8 +30,8 @@ import com.example.flush.core.designsystem.component.Loading
 import com.example.flush.core.designsystem.component.TopBar
 import com.example.flush.core.designsystem.theme.dimensions.IconSize
 import com.example.flush.core.designsystem.theme.dimensions.Paddings
-import com.example.flush.feature.search.SearchScreenDimensions.UserIconBorderWidth
 import com.example.flush.core.utils.showToast
+import com.example.flush.feature.search.SearchScreenDimensions.UserIconBorderWidth
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 

--- a/feature/search/src/main/java/com/example/flush/feature/search/SearchScreenBottomSheet.kt
+++ b/feature/search/src/main/java/com/example/flush/feature/search/SearchScreenBottomSheet.kt
@@ -32,13 +32,13 @@ import com.example.flush.core.designsystem.theme.dimensions.Alpha
 import com.example.flush.core.designsystem.theme.dimensions.IconSize
 import com.example.flush.core.designsystem.theme.dimensions.Paddings
 import com.example.flush.core.designsystem.theme.dimensions.Weights
-import com.example.flush.core.model.forEach
-import com.example.flush.ktx.toFormattedTime
-import com.example.flush.feature.search.SearchScreenDimensions.ParameterThickness
-import com.example.flush.feature.search.SearchScreenDimensions.PreviewImageHeight
 import com.example.flush.core.model.Emotion
 import com.example.flush.core.model.EmotionType
 import com.example.flush.core.model.ThrowingItem
+import com.example.flush.core.model.forEach
+import com.example.flush.core.utils.ktx.toFormattedTime
+import com.example.flush.feature.search.SearchScreenDimensions.ParameterThickness
+import com.example.flush.feature.search.SearchScreenDimensions.PreviewImageHeight
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import java.util.Locale


### PR DESCRIPTION
## 概要
detektを実行しても、appモジュールにしか実行されない様になっていた（分割した他のモジュールに対してdetektが実行されていなかった）。そのため、全てのモジュールに対して実行されるように変更を行った。
今後、build-logicを導入するにあたって今回対処した方法ではない方法で全てのモジュールに対してdetektを実行するように変更する。

## 実施Issue
#18 

<!-- 以下は、条件に当てはまった際に使用 -->
<!-- バグの修正の際にのみ使用 -->
## 原因と対処
appモジュール内のbuild.gradle.ktsにdetektの設定を行っていたのが原因、そのためプロジェクト直下のbuild.gradle.ktsでdetektの設定を行うように変更を行った。
